### PR TITLE
Fixing group assign logic

### DIFF
--- a/src/uSync.MemberEdition/Serializers/MemberHandler.cs
+++ b/src/uSync.MemberEdition/Serializers/MemberHandler.cs
@@ -297,7 +297,7 @@ namespace uSync.MemberEdition.Serializers
 					case GroupsNode:
 						foreach (var group in el.Elements())
 						{
-							groups.Add(el.Value);
+							groups.Add(group.Value);
 						}
 						break;
 


### PR DESCRIPTION
Needed this package to import members but kept getting error for roleNames when assiging roles.
Further debugged and realized when it's assiging groups when it needed to get the individual group values it was getting the whole element's values and creating a string where was not right. 
This PR fixes the group assigning logic.